### PR TITLE
fix: step_07 EOFError crash + add --verbose to run_checks.py

### DIFF
--- a/run_checks.py
+++ b/run_checks.py
@@ -939,12 +939,21 @@ def main() -> None:
     parser.add_argument("--preprocess-export", action="store_true",
                         help="Run kicad-cli auto-export over --corpus-dir before the eligibility "
                              "scan (materializes .net files for .kicad_sch/.sch sources that lack one).")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Raise logging from WARNING to INFO. main.py's single-netlist path "
+                             "defaults to INFO; this runner defaults to WARNING to keep corpus "
+                             "runs quiet, which also hides info-level diagnostics — e.g. the "
+                             "extraction-time advisory plausibility guard (see LIMITATIONS.md) — "
+                             "on this entrypoint. Pass --verbose to see them.")
     parser.add_argument("--staging", action="store_true",
                         help="Serve pin-group caches from the unpromoted staging tier "
                              "(schematic_checker_poc/datasheets_staged/) on a clean canonical "
                              "MISS. OFF by default — the precision gate and every baseline run "
                              "are staging-blind (R-B). TODO-386.")
     args = parser.parse_args()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.INFO)
 
     # TODO-386 Phase 3 (S2): exported rather than threaded through
     # PipelineContext because run_one executes in a worker process — the env var

--- a/schematic_checker_poc/steps/step_07_confirm.py
+++ b/schematic_checker_poc/steps/step_07_confirm.py
@@ -54,7 +54,14 @@ def confirm_voltages(power_rails: list[dict], skip: bool = False) -> dict[str, f
 
     print("\n  Enter corrections as: <number>=<voltage>")
     print("  Example: 1=3.3 2=5.0")
-    raw = input("  Press Enter to accept all: ").strip()
+    try:
+        raw = input("  Press Enter to accept all: ").strip()
+    except EOFError:
+        # No interactive input available (stdin closed or non-TTY — e.g. a
+        # backgrounded or piped run without --skip-confirm). Accept all
+        # inferred voltages instead of crashing with a raw traceback.
+        raw = ""
+        print("  (no input available — accepting all inferred voltages)")
     print("─" * 41 + "\n")
 
     # TODO-134 precedence: a user-map declaration (source="user_confirmed") is the

--- a/schematic_checker_poc/tests/test_run_checks_verbosity.py
+++ b/schematic_checker_poc/tests/test_run_checks_verbosity.py
@@ -1,0 +1,50 @@
+"""run_checks.py --verbose: raises logging from the runner's WARNING default to
+INFO, matching main.py's single-netlist path.
+
+main.py defaults to INFO; run_checks.py defaults to WARNING (to keep full
+corpus runs quiet) and, until this flag, had no way to raise it back for a
+single --board run — so info-level diagnostics (e.g. the extraction-time
+advisory plausibility guard named in LIMITATIONS.md) were invisible under the
+README's documented demo entrypoint. See CONTRIBUTING.md: this is a
+verdict-inert CLI/logging change, not a checker change.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BOARD = REPO / "examples/my_stm32_board_i2c_swap/my_stm32_board_i2c_swap.net"
+
+try:
+    from steps import step_03_l2_ext as _l2_ext
+    _CREDENTIAL_ENV_VARS = _l2_ext.CREDENTIAL_ENV_VARS
+except Exception:
+    _CREDENTIAL_ENV_VARS = ()
+
+_ISOLATED_ENV = {
+    k: v for k, v in os.environ.items() if k not in _CREDENTIAL_ENV_VARS
+}
+
+
+def _run(tmp_path, verbose):
+    cmd = [sys.executable, str(REPO / "run_checks.py"),
+           "--board", str(BOARD), "--skip-confirm",
+           "--output-dir", str(tmp_path)]
+    if verbose:
+        cmd.append("--verbose")
+    return subprocess.run(cmd, capture_output=True, text=True, env=_ISOLATED_ENV)
+
+
+def test_default_verbosity_suppresses_info_level_report_written_line(tmp_path):
+    r = _run(tmp_path, verbose=False)
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    # PIPELINE.md documents this exact line as "logged below the default
+    # threshold and does not print" -- it's the info-level marker this test
+    # pins on.
+    assert "[STEP 10] Report written to" not in r.stderr
+
+def test_verbose_flag_surfaces_info_level_report_written_line(tmp_path):
+    r = _run(tmp_path, verbose=True)
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    assert "[STEP 10] Report written to" in r.stderr

--- a/schematic_checker_poc/tests/test_step_07_confirm.py
+++ b/schematic_checker_poc/tests/test_step_07_confirm.py
@@ -1,0 +1,75 @@
+"""Step 07 (voltage confirmation) — the interactive-prompt path.
+
+Covers the EOFError fix: confirm_voltages() must accept all inferred
+voltages rather than crash with a raw traceback when stdin has no
+interactive input available (piped or backgrounded run, --skip-confirm not
+set). See CONTRIBUTING.md — this is a verdict-inert bug fix, not a checker
+change.
+"""
+import builtins
+
+import pytest
+
+from steps.step_07_confirm import confirm_voltages
+
+
+def _rail(net_name, voltage_v, source="deterministic", confidence="high"):
+    return {
+        "net_name": net_name,
+        "voltage_v": voltage_v,
+        "source": source,
+        "confidence": confidence,
+    }
+
+
+def test_eof_on_input_accepts_all_inferred_voltages(monkeypatch, capsys):
+    """A closed/non-TTY stdin must not raise — it should behave like pressing
+    Enter (accept every inferred voltage), not crash the run."""
+    def _raise_eof(*_args, **_kwargs):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", _raise_eof)
+
+    rails = [_rail("+3V3", 3.3), _rail("+5V", 5.0)]
+    result = confirm_voltages(rails, skip=False)
+
+    assert result == {"+3V3": 3.3, "+5V": 5.0}
+    # Should not have propagated EOFError.
+    captured = capsys.readouterr()
+    assert "accepting all inferred voltages" in captured.out
+
+
+def test_normal_interactive_accept_all(monkeypatch):
+    """Pressing Enter (empty line) still accepts all inferred voltages —
+    unaffected by the EOFError guard."""
+    monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "")
+
+    rails = [_rail("+3V3", 3.3)]
+    result = confirm_voltages(rails, skip=False)
+
+    assert result == {"+3V3": 3.3}
+
+
+def test_normal_interactive_correction_still_applies(monkeypatch):
+    """A real correction typed at the prompt still overrides the inferred
+    value — the EOFError guard must not interfere with the normal path."""
+    monkeypatch.setattr(builtins, "input", lambda *_a, **_k: "1=5.0")
+
+    rails = [_rail("+3V3", 3.3)]
+    result = confirm_voltages(rails, skip=False)
+
+    assert result == {"+3V3": 5.0}
+
+
+def test_skip_confirm_never_calls_input(monkeypatch):
+    """--skip-confirm bypasses the prompt entirely — input() must not even
+    be reachable, EOFError guard or not."""
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("input() should not be called when skip=True")
+
+    monkeypatch.setattr(builtins, "input", _fail)
+
+    rails = [_rail("+3V3", 3.3)]
+    result = confirm_voltages(rails, skip=True)
+
+    assert result == {"+3V3": 3.3}


### PR DESCRIPTION
Two small, unrelated, verdict-inert fixes — both in CONTRIBUTING.md's "straight to PR" category (obvious bug + CLI/logging hygiene), no checker behavior touched.

## 1. `step_07 confirm_voltages` crashes with a raw `EOFError` on non-TTY stdin

`confirm_voltages()` called `input()` with no EOF guard. Any `--board` run without `--skip-confirm` whose stdin has no interactive input available (piped, backgrounded, run under a supervisor) died with an unhandled traceback instead of a clean result.

Fix: catch `EOFError` around the prompt and accept all inferred voltages — the same outcome as pressing Enter. Confirmed live before/after:

```
$ python3 run_checks.py --board examples/my_stm32_board_i2c_fixed/my_stm32_board_i2c_fixed.net < /dev/null
```
Before: unhandled `EOFError` traceback, non-zero exit.
After: completes normally, exit 0.

## 2. `run_checks.py` has no logging-verbosity flag

`main.py` defaults to `INFO`; `run_checks.py` defaults to `WARNING` (deliberately, to keep full corpus runs quiet) but had no flag to raise it back. This makes info-level diagnostics invisible under the documented demo entrypoint — including the extraction-time advisory plausibility guard line LIMITATIONS.md already names:

> run the extraction with info-level logging enabled (`main.py` does this by default; `run_checks.py` does not and has no flag to raise it)

Adds `--verbose`/`-v`, raising the root logger to `INFO` after arg parsing. Default is unchanged — this only closes the "no flag at all" gap, it doesn't touch existing default behavior for corpus batch runs (that's a separate design call, out of scope here).

## Testing

Both changes ship with new tests (`test_step_07_confirm.py`, `test_run_checks_verbosity.py`). Full suite: `1166 passed, 32 skipped` (baseline before this branch: `1160 passed, 32 skipped`) — zero regressions, +6 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUsvpeWybGW8jUGQhF1Bz
