### PR TITLE
fix: git_dirty() ignores untracked files + stale CHECKER_SOURCE_FILES comment

### DIFF
--- a/corpus_baseline.py
+++ b/corpus_baseline.py
@@ -36,10 +36,19 @@ def git_sha(cwd: Optional[Path] = None) -> Optional[str]:
 
 
 def git_dirty(cwd: Optional[Path] = None) -> bool:
-    """Return True if the working tree has uncommitted changes."""
+    """Return True if the working tree has uncommitted changes to TRACKED files.
+
+    ``--untracked-files=no`` is deliberate: a bare ``git status --porcelain``
+    counts untracked scratch files (e.g. ``corpus_results/`` from a demo run)
+    as dirty, so every stranger clone with any scratch output -- and every dev
+    tree with the ordinary local cruft that accumulates between commits --
+    reports dirty even when the tracked tree exactly matches its commit. That
+    makes a genuinely dirty tracked tree indistinguishable from a clean one
+    wherever this flag feeds provenance (baseline filenames, report
+    metadata)."""
     try:
         r = subprocess.run(
-            ["git", "status", "--porcelain"],
+            ["git", "status", "--porcelain", "--untracked-files=no"],
             capture_output=True, text=True, timeout=5, cwd=cwd,
         )
         return bool(r.stdout.strip())

--- a/schematic_checker_poc/provenance.py
+++ b/schematic_checker_poc/provenance.py
@@ -83,7 +83,8 @@ CORE_PIPELINE_FILES = (
     "steps/rail_map.py",
 )
 
-# CHECKER_SOURCE_FILES = CORE + the registry-derived checker files (08/08b/08c/08d/08e).
+# CHECKER_SOURCE_FILES = CORE + the registry-derived checker files (08/08b/08c/08d/08e/08g,
+# m2_output_conflict — 7 members; see steps/checker_registry.py's REGISTRY).
 # step_08e ENTERS the code axis here for the first time = the folded TODO-168 stopgap (a single
 # era break, DECISION D2). From this commit forward every cached report reads stale on the code
 # axis — BY DESIGN; the full recall re-run is Phase 5, not this task. (checker_code_hash sorts the

--- a/schematic_checker_poc/tests/test_git_dirty.py
+++ b/schematic_checker_poc/tests/test_git_dirty.py
@@ -1,0 +1,63 @@
+"""corpus_baseline.git_dirty() — must ignore untracked files.
+
+A bare `git status --porcelain` counts untracked scratch output (e.g. a
+demo run's corpus_results/) as "dirty", so a tracked tree that exactly
+matches its own commit was misreported as dirty. Fixed via
+--untracked-files=no. Verdict-inert -- git_dirty feeds provenance metadata
+(baseline filenames, report "git_dirty" field) only, never a checker
+verdict.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import corpus_baseline  # noqa: E402
+
+
+def _init_repo(path):
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+
+
+def _commit_all(path, message="init"):
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=path, check=True)
+
+
+def test_untracked_file_alone_is_not_dirty(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    _commit_all(tmp_path)
+
+    (tmp_path / "scratch_output.json").write_text("{}\n")  # untracked, uncommitted
+
+    assert corpus_baseline.git_dirty(cwd=tmp_path) is False
+
+
+def test_modified_tracked_file_is_dirty(tmp_path):
+    _init_repo(tmp_path)
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("v1\n")
+    _commit_all(tmp_path)
+
+    tracked.write_text("v2\n")  # real change to a tracked file
+
+    assert corpus_baseline.git_dirty(cwd=tmp_path) is True
+
+
+def test_clean_tree_with_untracked_file_present_is_not_dirty(tmp_path):
+    """The exact regression case: a clean tracked tree plus scratch output
+    (e.g. corpus_results/ from a demo run) must not read as dirty."""
+    _init_repo(tmp_path)
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    _commit_all(tmp_path)
+
+    scratch_dir = tmp_path / "corpus_results"
+    scratch_dir.mkdir()
+    (scratch_dir / "report.json").write_text("{}\n")
+
+    assert corpus_baseline.git_dirty(cwd=tmp_path) is False


### PR DESCRIPTION
Two more small, unrelated, verdict-inert fixes — same "straight to PR" category as #2 (obvious bug + a stale comment), no checker behavior touched.

## 1. `git_dirty()` counts untracked files

`corpus_baseline.git_dirty()` ran a bare `git status --porcelain`, which includes untracked files. Any scratch output sitting in the working tree — e.g. `corpus_results/` after running the README's own documented demo command — makes a tracked tree that exactly matches its own commit report as dirty: baseline filenames get a spurious `-dirty` suffix, and the report's `git_dirty` provenance field reads `true` when nothing tracked actually changed.

Fix: `--untracked-files=no`. Only real changes to tracked files count now. `git_dirty` feeds provenance/baseline-naming metadata only (`save_baseline`'s filename, the report's `git_dirty` field) — never a checker verdict.

New test (`test_git_dirty.py`) exercises the real function against a real temp git repo: untracked-file-only → not dirty, modified tracked file → dirty, clean tree + untracked scratch dir (the exact regression shape) → not dirty.

## 2. Stale `CHECKER_SOURCE_FILES` comment in `provenance.py`

The comment above `CHECKER_SOURCE_FILES` named the registry-derived checker files as `(08/08b/08c/08d/08e)` — 5 files. `steps/checker_registry.py`'s `REGISTRY` has carried `step_08g_pullup_presence` and `m2_output_conflict` for a while (7 members total; verified live against the registry). A reader tracing `checker_code_hash` membership from the comment alone would wrongly conclude those two checkers sit outside the verdict-affecting code axis. Docs-only, no behavior change.

## Testing

Full suite: `1163 passed, 32 skipped` (main baseline: `1160 passed, 32 skipped`) — zero regressions, +3 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUsvpeWybGW8jUGQhF1Bz
