### PR TITLE
fix: too-short-MPN error message quotes original value but reports stripped length

### DIFF
--- a/schematic_checker_poc/steps/step_03_resolver.py
+++ b/schematic_checker_poc/steps/step_03_resolver.py
@@ -1930,9 +1930,15 @@ def resolve_and_parse(part_number: str) -> dict:
 
     base_pn = BASE_SUFFIX_RE.sub("", part_number).strip()
     if len(base_pn) < MIN_MPN_LENGTH:
+        # The length compared against MIN_MPN_LENGTH is base_pn's, AFTER
+        # BASE_SUFFIX_RE strips a trailing grade/package suffix (e.g.
+        # 'flsh1' -> 'fl') -- not part_number's own length. Naming both
+        # values here avoids a message that looks self-contradictory (a
+        # visibly-5-character part_number reported as "length 2").
         raise FileNotFoundError(
             f"Part number '{part_number}' is too short to be a real MPN "
-            f"(length {len(base_pn)} < {MIN_MPN_LENGTH}) — "
+            f"(base MPN '{base_pn}' after suffix-strip: length {len(base_pn)} "
+            f"< {MIN_MPN_LENGTH}) — "
             f"likely a generic value. Add MPN field to schematic component."
         )
 

--- a/schematic_checker_poc/tests/test_short_mpn_message.py
+++ b/schematic_checker_poc/tests/test_short_mpn_message.py
@@ -1,0 +1,53 @@
+"""resolve_and_parse's too-short-MPN message.
+
+The length compared against MIN_MPN_LENGTH is base_pn's -- part_number
+AFTER BASE_SUFFIX_RE strips a trailing grade/package suffix -- not
+part_number's own length. The message must name both, since quoting only
+the untouched part_number next to the stripped length reads as
+self-contradictory ('flsh1' ... length 2 < 4).
+
+pipeline.py substring-matches "is too short to be a real MPN" to bucket
+this error into the aggregated short-MPN warning (LT-21) -- that phrase
+must survive verbatim.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from steps import step_03_resolver
+
+
+@pytest.fixture(autouse=True)
+def _isolated_resolver_dirs(tmp_path, monkeypatch):
+    """resolve_and_parse creates DATASHEETS_DIR/PARSED_DIR unconditionally
+    before the length check -- point both at tmp_path so this test touches
+    nothing in the repo tree."""
+    monkeypatch.setattr(step_03_resolver, "DATASHEETS_DIR", str(tmp_path / "datasheets"))
+    monkeypatch.setattr(step_03_resolver, "PARSED_DIR", str(tmp_path / "parsed"))
+    monkeypatch.setattr(step_03_resolver, "_l2_resolve_ok", lambda: False)
+
+
+def test_message_names_both_original_and_stripped_value():
+    with pytest.raises(FileNotFoundError) as exc_info:
+        step_03_resolver.resolve_and_parse("flsh1")
+
+    msg = str(exc_info.value)
+    # The exact phrase pipeline.py's aggregation logic matches on.
+    assert "is too short to be a real MPN" in msg
+    # Both the untouched value and the value actually measured must appear,
+    # so the message doesn't look self-contradictory.
+    assert "'flsh1'" in msg
+    assert "'fl'" in msg
+    assert "length 2 < 4" in msg
+
+
+def test_short_generic_value_with_no_suffix_still_raises():
+    with pytest.raises(FileNotFoundError) as exc_info:
+        step_03_resolver.resolve_and_parse("10k")
+
+    msg = str(exc_info.value)
+    assert "is too short to be a real MPN" in msg
+    assert "'10k'" in msg


### PR DESCRIPTION
Small, self-contained message fix — no logic change, no checker behavior touched.

`resolve_and_parse`'s length-floor check compares `len(base_pn)` — `part_number` **after** `BASE_SUFFIX_RE` strips a trailing grade/package suffix (e.g. `flsh1` → `fl`) — against `MIN_MPN_LENGTH`, but the raised message quoted only the untouched `part_number`. A value like `'flsh1'` (visibly 5 characters) produced:

```
Part number 'flsh1' is too short to be a real MPN (length 2 < 4) — likely a generic value.
```

Technically correct, but reads as self-contradictory to anyone debugging via the JSON report or logs. (This message isn't shown verbatim in normal console output — `pipeline.py` only substring-matches `"is too short to be a real MPN"` to bucket it into the aggregated short-MPN warning, so this is low-stakes, but worth fixing for anyone who does end up staring at it.)

**Fix**: name both the original `part_number` and the stripped `base_pn` in the message. The `"is too short to be a real MPN"` substring `pipeline.py` matches on is preserved verbatim.

**No logic change** — the same parts get rejected exactly as before. `BASE_SUFFIX_RE`'s stripping is the same transform `_find_pdf` and `_scan_cache_root` already rely on for real resolution (verified — both call sites use identical `BASE_SUFFIX_RE.sub("", part_number)`), so this isn't a new or newly-aggressive rule, just a clearer report of an existing one.

## Testing

New tests (`test_short_mpn_message.py`) cover the suffix-stripped case (`'flsh1'` → base `'fl'`) and a no-suffix short value (`'10k'`). Full suite: `1162 passed, 32 skipped` (main baseline `1160 passed`) — zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUsvpeWybGW8jUGQhF1Bz
