### PR TITLE
feat: examples-smoke gate — verify shipped fixtures against their own provenance.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,14 +76,20 @@ Run the test suite:
 
     make test
 
-The shipped `Makefile` has exactly two targets — `help` and `test`.
-That is deliberate: the private development repo's other targets all
-reach corpus data and tooling that don't ship, so the public file
-carries only what a clone can actually run. `make test` expects the
-`venv/` layout from the README's Install section, installs its own
-test dependencies (`requirements-dev.txt`) on first run, and runs
+The shipped `Makefile` has three targets — `help`, `test`, and
+`examples-smoke`. That is deliberate: the private development repo's
+other targets all reach corpus data and tooling that don't ship, so
+the public file carries only what a clone can actually run. `make test`
+expects the `venv/` layout from the README's Install section, installs
+its own test dependencies (`requirements-dev.txt`) on first run, runs
 the shipped subset of the suite — integration tests and tests that
-need external services are excluded by marker.
+need external services are excluded by marker — and finishes by
+running `examples-smoke`: every fixture under `examples/` gets run
+fresh and its findings diffed against the `expected_verdict` block in
+its own `provenance.json`. A fixture whose actual output has drifted
+from what its sidecar documents fails the gate; this is the mechanism
+that keeps the "a skip on a fixture-backed test is a bug" rule below
+honest for verdicts, not just for whether the test runs at all.
 
 Skips are normal and environment-conditional: some tests skip when
 optional inputs aren't present, and the count varies between
@@ -98,6 +104,8 @@ repo root:
     venv/bin/pip install -r requirements.txt -r requirements-dev.txt
     cd schematic_checker_poc
     ../venv/bin/python3 -m pytest -q -m "not integration and not gemma_smoke"
+    cd ..
+    venv/bin/python3 examples_smoke.py
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PY    := venv/bin/python3
 
 .DEFAULT_GOAL := help
 
-.PHONY: help test
+.PHONY: help test examples-smoke
 
 help:  ## Show this target list
 	@echo "DeepERC runbook targets  (python env: $(PY))"
@@ -39,3 +39,10 @@ test:  ## Test gate — pytest minus the external-dependency tests
 	    exit 1; }; }
 	cd schematic_checker_poc && set -o pipefail && \
 	  ../$(PY) -m pytest -q -m "not integration and not gemma_smoke"
+	@$(MAKE) examples-smoke
+
+examples-smoke:  ## Verify every examples/*/ fixture still matches its documented expected_verdict
+	@test -x $(PY) || { \
+	  echo "ERROR: $(PY) not found. Create the venv first (see README's Install section)."; \
+	  exit 1; }
+	$(PY) examples_smoke.py

--- a/examples/stm32_spi_swap/ATTRIBUTION.md
+++ b/examples/stm32_spi_swap/ATTRIBUTION.md
@@ -1,0 +1,17 @@
+# Attribution
+
+Unlike this repo's other `examples/` fixtures — which are deliberately mutated
+copies of real, third-party open-source boards — the netlist in this directory
+(`spi_swap_stm32.net`) is **original, hand-authored work**. There is no
+upstream project to attribute.
+
+It's a minimal, purpose-built two-part design: an STM32F103C8Tx (KiCad's
+unedited stock symbol) wired to an ADS8319 SPI ADC, with MOSI and MISO crossed
+on the MCU side (PA6/PA7). It exists specifically to demonstrate the case
+where an MCU-side SPI swap has to be caught from the peripheral knowledge base
+alone — the MCU's symbol pins carry no SPI-specific names, so there's no
+net-name shortcut available to the checker. See `provenance.json` for the
+exact expected findings.
+
+Licensed under this repository's own license (see `LICENSE` at the repo
+root) — no third-party license terms apply.

--- a/examples/stm32_spi_swap/provenance.json
+++ b/examples/stm32_spi_swap/provenance.json
@@ -1,0 +1,44 @@
+{
+  "fixture_file": "examples/stm32_spi_swap/spi_swap_stm32.net",
+  "purpose": "Second SPI/M12-shape fixture in the README (MCU-side MOSI/MISO swap detected with no datasheet needed) and the sole shipped SPI-family fixture in examples/ -- TODO-410's promoted deliverable. Adding this file only closes the missing-sidecar/attribution gap flagged by the per-detector example pack effort; the fixture itself already ships and is already documented in the README's SPI walkthrough.",
+  "source": {
+    "origin": "hand-authored, original -- not derived from a third-party board",
+    "note": "Unlike this repo's other examples/ fixtures (which are deliberately mutated copies of real open-source designs), this netlist has no upstream to attribute: it's a minimal, purpose-built two-part design (an STM32F103C8Tx using KiCad's unedited stock symbol, wired to an ADS8319 SPI ADC) constructed specifically to demonstrate an MCU-side SPI MOSI/MISO swap on a board whose MCU symbol pins carry no SPI-specific names -- the finding has to come from the peripheral knowledge base alone, which is the scenario worth having a dedicated fixture for."
+  },
+  "license": {
+    "note": "Original work, no upstream license to carry forward. Licensed under this repo's own license (see LICENSE at repo root)."
+  },
+  "mutation": {
+    "description": "Not a mutation of a pre-existing correct board -- MOSI/MISO are crossed on the MCU side (PA6/PA7) by construction. There is no 'unswapped' precursor for this specific fixture (unlike the I2C swap/fixed pair).",
+    "component": "U1 (STM32F103C8Tx)",
+    "pins": {"PA6": "wired to /MOSI (SPI MISO pin function, per KB)", "PA7": "wired to /MISO (SPI MOSI pin function, per KB)"}
+  },
+  "expected_verdict": {
+    "board_status": "has_fail",
+    "peripheral_checks": {"total": 2, "pass": 0, "warn": 0, "fail": 2, "unresolvable": 0},
+    "signal_checks": {"total": 4, "pass": 0, "warn": 0, "fail": 0, "unresolvable": 4},
+    "supply_checks": {"total": 5, "pass": 1, "warn": 0, "fail": 0, "unresolvable": 4},
+    "structural_checks": {"total": 10, "pass": 10, "warn": 0, "fail": 0},
+    "fail_findings": [
+      {
+        "net": "/MOSI",
+        "violation": "ROLE_MISMATCH",
+        "severity": "FAIL",
+        "pins": ["U1.16"],
+        "evidence": "Pin U1.16 (function 'PA6') is an SPI MISO pin but sits on net '/MOSI', whose name implies SPI MOSI — MOSI/MISO swap (role source: kb_possible_roles). (MCU KB — no datasheet required)"
+      },
+      {
+        "net": "/MISO",
+        "violation": "ROLE_MISMATCH",
+        "severity": "FAIL",
+        "pins": ["U1.17"],
+        "evidence": "Pin U1.17 (function 'PA7') is an SPI MOSI pin but sits on net '/MISO', whose name implies SPI MISO — MOSI/MISO swap (role source: kb_possible_roles). (MCU KB — no datasheet required)"
+      }
+    ],
+    "confidence": "high (KB-sourced pin role, unambiguous, MCU KB evidence -- no datasheet involved)",
+    "unrelated_unresolvables": "4 signal + 4 supply UNRESOLVABLE (net voltage not confirmed, no rails.json sidecar) and 0 peripheral UNRESOLVABLE -- present with or without the swap; not injected by this fixture's construction",
+    "unchanged_axes": "pullup_value 0, output_conflict 0 FAIL, pullup_presence 0 WARN"
+  },
+  "verified_by": "python3 run_checks.py --board examples/stm32_spi_swap/spi_swap_stm32.net --skip-confirm",
+  "date": "2026-09-07"
+}

--- a/examples_smoke.py
+++ b/examples_smoke.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+examples_smoke.py — verify every examples/*/provenance.json fixture still
+produces the findings it documents.
+
+Runs each example board through run_checks.py --board (fresh, isolated
+--output-dir per fixture), loads the resulting JSON report, and diffs the
+board's classified status plus each checker-family bucket named in the
+fixture's provenance.json "expected_verdict" block against the live result.
+
+Only the structured fields (board_status + <family>_checks pass/warn/fail/
+unresolvable counts) are diffed -- the prose fields (unrelated_unresolvables,
+unchanged_axes, confidence) are documentation for a human reader, not
+mechanically checked here.
+
+A fixture without a provenance.json, or one whose provenance.json lacks an
+"expected_verdict" block, is reported and skipped rather than silently
+ignored -- CONTRIBUTING.md's fixture-honesty principle applies to the smoke
+gate itself.
+
+Usage:
+    python3 examples_smoke.py
+Exit code 0 if every fixture's actual output matches its documented
+expected_verdict; 1 otherwise.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent
+EXAMPLES_DIR = REPO_ROOT / "examples"
+POC_DIR = REPO_ROOT / "schematic_checker_poc"
+sys.path.insert(0, str(POC_DIR))
+
+from pipeline import classify_report  # noqa: E402
+
+
+def find_fixtures():
+    """One (net_file, provenance_json) pair per examples/*/ subdirectory that
+    has exactly one .net file. Directories without a provenance.json are
+    still yielded (provenance=None) so they're reported, not silently
+    skipped."""
+    fixtures = []
+    for d in sorted(EXAMPLES_DIR.iterdir()):
+        if not d.is_dir():
+            continue
+        nets = list(d.glob("*.net"))
+        if len(nets) != 1:
+            continue
+        prov_path = d / "provenance.json"
+        provenance = json.loads(prov_path.read_text()) if prov_path.exists() else None
+        fixtures.append((d.name, nets[0], provenance))
+    return fixtures
+
+
+def run_board(net_path: Path, out_dir: Path) -> dict:
+    cmd = [sys.executable, str(REPO_ROOT / "run_checks.py"),
+           "--board", str(net_path), "--skip-confirm",
+           "--output-dir", str(out_dir)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"run_checks.py exited {result.returncode}\n"
+                            f"stdout: {result.stdout}\nstderr: {result.stderr}")
+    report_path = out_dir / "reports" / f"{net_path.stem}.json"
+    if not report_path.exists():
+        raise RuntimeError(f"expected report not written: {report_path}\n"
+                            f"stdout: {result.stdout}\nstderr: {result.stderr}")
+    return json.loads(report_path.read_text())
+
+
+def diff_family_checks(name: str, expected: dict, actual: dict) -> list[str]:
+    """Compares only the keys present in `expected` -- a fixture's
+    provenance.json need not enumerate every key the live summary carries."""
+    problems = []
+    for key, expected_val in expected.items():
+        actual_val = actual.get(key)
+        if actual_val != expected_val:
+            problems.append(f"    {name}.{key}: expected {expected_val}, got {actual_val}")
+    return problems
+
+
+def main() -> int:
+    fixtures = find_fixtures()
+    any_failure = False
+    any_skipped = False
+
+    print(f"examples_smoke: {len(fixtures)} fixture(s) found under examples/\n")
+
+    for fixture_name, net_path, provenance in fixtures:
+        print(f"=== {fixture_name} ===")
+        if provenance is None:
+            print("  SKIP: no provenance.json")
+            any_skipped = True
+            continue
+        expected = provenance.get("expected_verdict")
+        if expected is None:
+            print("  SKIP: provenance.json has no \"expected_verdict\" block")
+            any_skipped = True
+            continue
+
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                report = run_board(net_path, Path(tmp))
+            except Exception as e:
+                print(f"  FAIL: could not run board: {e}")
+                any_failure = True
+                continue
+
+        problems = []
+        actual_status = classify_report(report)
+        expected_status = expected.get("board_status")
+        if expected_status is not None and actual_status != expected_status:
+            problems.append(f"    board_status: expected {expected_status!r}, "
+                             f"got {actual_status!r}")
+
+        summary = report.get("summary", {})
+        for key, expected_val in expected.items():
+            if not key.endswith("_checks") or not isinstance(expected_val, dict):
+                continue
+            actual_val = summary.get(key, {})
+            problems.extend(diff_family_checks(key, expected_val, actual_val))
+
+        if problems:
+            print("  FAIL:")
+            for p in problems:
+                print(p)
+            any_failure = True
+        else:
+            print("  OK")
+
+    print()
+    if any_failure:
+        print("examples_smoke: FAILED — one or more fixtures drifted from their "
+              "documented expected_verdict.")
+        return 1
+    if any_skipped:
+        print("examples_smoke: PASSED (with skips) — every checked fixture matched; "
+              "some fixtures have no expected_verdict to check against.")
+        return 0
+    print("examples_smoke: PASSED — every fixture matches its documented expected_verdict.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/schematic_checker_poc/tests/test_examples_smoke.py
+++ b/schematic_checker_poc/tests/test_examples_smoke.py
@@ -1,0 +1,91 @@
+"""examples_smoke.py — the per-fixture expected_verdict gate (make examples-smoke).
+
+Covers the pure diff logic directly (no pipeline run needed), plus one
+subprocess-level integration assertion that the real shipped examples/
+fixtures currently pass their own gate -- a genuine regression pin: if a
+future checker change silently moves a shipped fixture's verdict, this
+test (and `make test`, which chains examples-smoke after pytest) catches
+it, not just a human re-reading the README by hand.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+import examples_smoke  # noqa: E402
+
+try:
+    from steps import step_03_l2_ext as _l2_ext
+    _CREDENTIAL_ENV_VARS = _l2_ext.CREDENTIAL_ENV_VARS
+except Exception:
+    _CREDENTIAL_ENV_VARS = ()
+
+_ISOLATED_ENV = {k: v for k, v in os.environ.items() if k not in _CREDENTIAL_ENV_VARS}
+
+
+def test_diff_family_checks_reports_only_mismatched_keys():
+    expected = {"pass": 5, "warn": 0, "fail": 0, "unresolvable": 0}
+    actual = {"pass": 5, "warn": 0, "fail": 1, "unresolvable": 0}
+    problems = examples_smoke.diff_family_checks("supply_checks", expected, actual)
+    assert len(problems) == 1
+    assert "supply_checks.fail" in problems[0]
+    assert "expected 0" in problems[0]
+    assert "got 1" in problems[0]
+
+
+def test_diff_family_checks_agree_on_full_match():
+    expected = {"pass": 2, "warn": 0, "fail": 2, "unresolvable": 0}
+    assert examples_smoke.diff_family_checks("peripheral_checks", expected, expected) == []
+
+
+def test_diff_family_checks_ignores_keys_not_in_expected():
+    """A fixture's expected_verdict need not enumerate every key the live
+    summary carries -- only what's named is checked."""
+    expected = {"fail": 2}
+    actual = {"fail": 2, "pass": 0, "warn": 0, "unresolvable": 99}
+    assert examples_smoke.diff_family_checks("peripheral_checks", expected, actual) == []
+
+
+def test_find_fixtures_discovers_every_shipped_example_with_exactly_one_net():
+    fixtures = examples_smoke.find_fixtures()
+    names = {name for name, _, _ in fixtures}
+    # every example this repo ships as of this test's writing; a fixture
+    # dropped or renamed should fail this, not silently vanish from the gate.
+    expected_names = {
+        "my_stm32_board_floating_gnd", "my_stm32_board_i2c_fixed",
+        "my_stm32_board_i2c_swap", "my_stm32_board_output_conflict",
+        "my_stm32_board_pullup_presence", "my_stm32_board_pullup_value",
+        "my_stm32_board_supply_overvoltage", "stm32_spi_swap",
+    }
+    assert expected_names <= names
+
+
+def test_find_fixtures_every_shipped_example_has_a_provenance_json():
+    """Every shipped fixture should carry a provenance.json with an
+    expected_verdict -- a fixture that doesn't is invisible to the gate,
+    which is exactly the gap this smoke test exists to close."""
+    fixtures = examples_smoke.find_fixtures()
+    missing = [name for name, _, prov in fixtures if prov is None]
+    assert missing == [], f"fixture(s) with no provenance.json: {missing}"
+    no_expected = [name for name, _, prov in fixtures
+                   if prov is not None and "expected_verdict" not in prov]
+    assert no_expected == [], f"fixture(s) with no expected_verdict block: {no_expected}"
+
+
+def test_shipped_examples_pass_the_real_smoke_gate():
+    """Integration-level: run the actual script against the real examples/
+    tree. This is the regression pin -- if a checker change silently moves
+    a shipped fixture's verdict, this fails."""
+    result = subprocess.run(
+        [sys.executable, str(REPO / "examples_smoke.py")],
+        capture_output=True, text=True, timeout=120, env=_ISOLATED_ENV,
+    )
+    assert result.returncode == 0, (
+        f"examples_smoke.py failed against the real examples/ tree:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "PASSED" in result.stdout


### PR DESCRIPTION
Half of `deeperc/internal#10` ("Per-detector example pack + make examples-smoke gate", flagged there as "a good first substantial contribution"). This PR is the smoke-gate machinery + closing the one existing gap (`stm32_spi_swap` lacked provenance); it does **not** add new fixtures for the still-missing checker families (`signal`, and a real peripheral-IC-on-bus scenario) — flagging that as separate, larger follow-on work that needs careful new netlist authorship, not something to rush into this PR.

## What this adds

**`examples_smoke.py`** — runs every `examples/*/` fixture through `run_checks.py --board` fresh, then diffs the board's classified status and each documented checker-family bucket (`pass`/`warn`/`fail`/`unresolvable`) against the `expected_verdict` block already present in that fixture's `provenance.json`. No new sidecar format — every fixture already had an `expected_verdict` block (or now does), so this reuses it rather than inventing a second, driftable source of truth.

Wired in two places:
- `make test` now runs `examples-smoke` after pytest (adds ~1.6s — all 8 boards, no network, no LLM)
- The no-`make` raw-steps fallback in `CONTRIBUTING.md` gets the equivalent line

**Verified the gate actually gates** (not just rubber-stamps): deliberately corrupted one fixture's `expected_verdict.peripheral_checks.fail` to a wrong value, confirmed `examples_smoke.py` fails with the exact field/expected/actual, exit code 1; restored, confirmed it passes again.

**`examples/stm32_spi_swap/`** shipped with only a `.net` file — no `ATTRIBUTION.md`, no `provenance.json`, unlike every other example. Added both:
- `ATTRIBUTION.md` states plainly that this fixture is original/hand-authored (not a mutated third-party board like the others) — no upstream to attribute, so nothing invented
- `provenance.json`'s `expected_verdict` was captured by actually running the board fresh and recording the real output, matching the README's own SPI walkthrough exactly

This brings fixture coverage to 8/8 with a `provenance.json` + `expected_verdict`.

**Docs**: `CONTRIBUTING.md` said the Makefile has "exactly two targets" — now three, updated accordingly, along with a short explanation of what the new gate checks and why (ties back to the existing "a skip on an examples/-backed test is a bug" rule one level up: a fixture that still *runs* but has silently drifted to a different verdict was previously only human-checkable).

## What this deliberately doesn't do

Per `deeperc/internal#10`'s full scope: still missing are (1) a fixture for the `signal` checker family (no shipped example specifically demonstrates it firing), and (2) a fixture with a real KB'd peripheral IC on a bus (today's I2C/SPI examples are all MCU-side pin-name coherence — none exercise `step_08d`'s consensus/bus-pairing logic against an actual peripheral IC). Both need real netlist authorship and, per `CONTRIBUTING.md`'s own rule on test fixtures, should probably get their own review pass rather than riding in on this PR.

## Testing

New tests in `test_examples_smoke.py`: pure diff-logic unit tests, a fixture-discovery/coverage assertion (every shipped example has a `provenance.json` with `expected_verdict`), and one subprocess-level integration test that the real shipped examples currently pass the real gate — a genuine regression pin.

Full suite: `1171 passed, 32 skipped` — zero regressions. `make test` runs clean end to end (pytest + examples-smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUsvpeWybGW8jUGQhF1Bz
