### PR TITLE
fix: resolve_and_parse's eager directory creation + test_resume_reconstruction's arrival-state skip

### DIFF
--- a/schematic_checker_poc/steps/step_03_resolver.py
+++ b/schematic_checker_poc/steps/step_03_resolver.py
@@ -454,7 +454,15 @@ def _prune_staged_images(pdf_path: str, output_root) -> int:
 
 
 def _find_pdf(part_number: str) -> str | None:
-    pdfs = [f for f in os.listdir(DATASHEETS_DIR) if f.lower().endswith(".pdf")]
+    # A missing DATASHEETS_DIR means the same thing as an empty one -- no
+    # local PDF to find -- and must not raise. DATASHEETS_DIR is a directory
+    # the user populates themselves (README's own install instructions have
+    # them `mkdir -p` it); a fresh clone or a corpus-free --board run never
+    # creates it, so this path is reached on every such run, not an edge case.
+    try:
+        pdfs = [f for f in os.listdir(DATASHEETS_DIR) if f.lower().endswith(".pdf")]
+    except FileNotFoundError:
+        return None
 
     base_mpn = BASE_SUFFIX_RE.sub("", part_number)
 
@@ -1910,12 +1918,6 @@ def _save_patch_state(pdf_path: str, *, residual_unpatchable: int,
 
 
 def resolve_and_parse(part_number: str) -> dict:
-    os.makedirs(DATASHEETS_DIR, exist_ok=True)
-    os.makedirs(PARSED_DIR, exist_ok=True)
-    # TODO-388: magic-pdf's -o and the pdfplumber writers both target this
-    # run's bucket-B write root, which is the staging tier when staging is
-    # active — created lazily here, same as PARSED_DIR above.
-    os.makedirs(bucket_b_write_root(), exist_ok=True)
     # LT-23: decide L2 network-resolve availability once, at the first
     # resolver call of the run — eager so the disable line (if any) always
     # appears near STEP 03's start, regardless of which part first misses L1.
@@ -1941,6 +1943,19 @@ def resolve_and_parse(part_number: str) -> dict:
             f"< {MIN_MPN_LENGTH}) — "
             f"likely a generic value. Add MPN field to schematic component."
         )
+
+    # Directories are created here, not at function entry -- a short/generic
+    # value (the common case: "10k", "100n", ...) exits above via the
+    # MIN_MPN_LENGTH raise and never touches the filesystem. Every path past
+    # this point does need these to exist: _find_pdf lists DATASHEETS_DIR
+    # unconditionally, and a genuine L1 miss eventually writes into PARSED_DIR
+    # / bucket_b_write_root().
+    os.makedirs(DATASHEETS_DIR, exist_ok=True)
+    os.makedirs(PARSED_DIR, exist_ok=True)
+    # TODO-388: magic-pdf's -o and the pdfplumber writers both target this
+    # run's bucket-B write root, which is the staging tier when staging is
+    # active.
+    os.makedirs(bucket_b_write_root(), exist_ok=True)
 
     # L1: local PDF cache (filename match).
     resolver_used = "l1_local"

--- a/schematic_checker_poc/tests/test_find_pdf_missing_dir.py
+++ b/schematic_checker_poc/tests/test_find_pdf_missing_dir.py
@@ -1,0 +1,56 @@
+"""_find_pdf must tolerate a missing DATASHEETS_DIR.
+
+DATASHEETS_DIR is a directory the user populates themselves (README's own
+install instructions have them `mkdir -p` it) -- a fresh clone, or any
+--board run against a board with no local datasheets, never creates it.
+A missing directory means the same thing as an empty one: no local PDF
+found. It must not raise.
+
+Also covers resolve_and_parse's directory-creation timing (part of the
+same fix): a short/generic value must exit via the MIN_MPN_LENGTH raise
+before ever touching the filesystem, so it works even when the parent of
+DATASHEETS_DIR doesn't exist and isn't writable-into.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from steps import step_03_resolver
+
+
+def test_find_pdf_returns_none_on_missing_directory(tmp_path, monkeypatch):
+    missing = tmp_path / "does_not_exist"
+    assert not missing.exists()
+    monkeypatch.setattr(step_03_resolver, "DATASHEETS_DIR", str(missing))
+
+    assert step_03_resolver._find_pdf("SOME_PART") is None
+
+
+def test_find_pdf_still_finds_a_real_match(tmp_path, monkeypatch):
+    ds_dir = tmp_path / "datasheets"
+    ds_dir.mkdir()
+    (ds_dir / "STM32F103C8T6.pdf").write_bytes(b"%PDF-1.4 fake")
+    monkeypatch.setattr(step_03_resolver, "DATASHEETS_DIR", str(ds_dir))
+
+    found = step_03_resolver._find_pdf("STM32F103C8T6")
+    assert found is not None
+    assert found.endswith("STM32F103C8T6.pdf")
+
+
+def test_resolve_and_parse_short_value_never_touches_filesystem(tmp_path, monkeypatch):
+    """A generic passive value ('10k') must raise before any os.makedirs --
+    even when DATASHEETS_DIR's parent doesn't exist and can't be created."""
+    unwritable_parent = tmp_path / "no_such_parent"
+    fake_datasheets_dir = str(unwritable_parent / "datasheets")
+    monkeypatch.setattr(step_03_resolver, "DATASHEETS_DIR", fake_datasheets_dir)
+    monkeypatch.setattr(step_03_resolver, "PARSED_DIR", str(tmp_path / "parsed"))
+    monkeypatch.setattr(step_03_resolver, "_l2_resolve_ok", lambda: False)
+
+    with pytest.raises(FileNotFoundError, match="too short to be a real MPN"):
+        step_03_resolver.resolve_and_parse("10k")
+
+    # The short-value path must not have created anything.
+    assert not unwritable_parent.exists()

--- a/schematic_checker_poc/tests/test_resume_reconstruction.py
+++ b/schematic_checker_poc/tests/test_resume_reconstruction.py
@@ -9,6 +9,7 @@ as stale (re-run, not reused).
 """
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -78,12 +79,29 @@ def test_result_from_report_status_matches_classifier(tmp_path):
     assert rct.result_from_report(rp)["status"] == "has_unresolvable_only"
 
 
-# ── result_from_report round-trips a REAL corpus report (if present) ───────────
-def test_result_from_report_on_real_report_if_available():
-    reports = sorted((REPO_ROOT / "corpus_results" / "reports").glob("*.json"))
-    if not reports:
-        pytest.skip("no corpus reports on disk")
-    rp = reports[0]
+# ── result_from_report round-trips a REAL report ────────────────────────────
+def test_result_from_report_on_real_report(tmp_path):
+    """Round-trips a genuine on-disk report, not the hand-crafted _report()
+    shape above -- catches drift between what build_report actually writes
+    and what result_from_report expects to read.
+
+    Generates its own fixture (a shipped examples/ board, run fresh into
+    tmp_path) instead of globbing corpus_results/reports/ for whatever an
+    earlier, unrelated run happened to leave there: that made this test's
+    skip/run outcome -- and so the suite's total skip count -- depend on
+    arrival state, exactly the class of bug CONTRIBUTING.md's "a skip on a
+    test whose fixture ships in examples/ is a bug" rule exists to catch.
+    Never skips now."""
+    board = REPO_ROOT / "examples" / "my_stm32_board_i2c_swap" / "my_stm32_board_i2c_swap.net"
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "run_checks.py"),
+         "--board", str(board), "--skip-confirm", "--output-dir", str(tmp_path)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    rp = tmp_path / "reports" / f"{board.stem}.json"
+    assert rp.exists(), f"expected report not written: {rp}"
+
     report = json.loads(rp.read_text())
     r = rct.result_from_report(rp)
     # Reconstructed counts equal the report's own summary block.


### PR DESCRIPTION
Addresses two of the three instances named in `deeperc/internal#15` ("Order-dependent behavior from leftover on-disk state"). Both verified in a clean, git-free copy of the tree before and after.

## 1. `resolve_and_parse` created datasheet directories unconditionally, even on immediate reject

Directory creation (`os.makedirs` on `DATASHEETS_DIR`/`PARSED_DIR`/`bucket_b_write_root()`) ran at function entry — before the `MIN_MPN_LENGTH` check — so every call, including a generic passive value (`"10k"`, `"100n"`, ...) that raises `FileNotFoundError` two lines later and touches nothing else, created `netlist_corpus/datasheets/` on disk. `resolve_and_parse` runs once per component, so this fired on every board, every run, even a `--board` run with a fully warm cache and zero real resolution needs.

**Fix**: move directory creation past the short-value early-exit — it only happens once a part number reaches a genuine resolution attempt. Also hardened `_find_pdf` to tolerate a missing `DATASHEETS_DIR` (returns `None` instead of raising) since that directory is one the user populates themselves per the README's own install instructions (`mkdir -p netlist_corpus/datasheets/...`) — the app has no business requiring it to pre-exist just to look inside it.

**Honest scope note**: boards whose non-cached parts are all short/generic values now create nothing at all. Boards with real non-cached connector/crystal-class part numbers — which includes this repo's own shipped examples — still create the directory, because a genuine resolution attempt is legitimately happening at that point. That's correct behavior, not the defect this fixes; full elimination for those boards isn't attempted here (see below).

## 2. `test_resume_reconstruction`'s skip count depended on ambient `corpus_results/` state

`test_result_from_report_on_real_report_if_available` globbed `corpus_results/reports/*.json` and skipped when empty. Whether this test ran or skipped depended entirely on whatever an earlier, unrelated invocation happened to leave on disk — two runs of the same suite, same commit, could report different skip counts.

**Fix**: the test now generates its own fixture (runs a shipped `examples/` board fresh into `tmp_path`) instead of depending on ambient state. Never skips. This is `CONTRIBUTING.md`'s own rule ("a skip on a test whose fixture ships in `examples/` is a bug") applied one level up — to a test's dependency on a fixture it was never guaranteed to have.

## What this doesn't fix (the card's 3rd instance + a related observation)

- **"make test creates the datasheets dir too"** — per the analysis above, this is a *consequence* of instance 1's root cause on boards with real un-cached parts, not eliminable without either (a) changing `_find_pdf`'s directory-existence assumption further (done, see above) or (b) verifying the private-tier L2 vendor-download path doesn't rely on `resolve_and_parse` pre-creating `DATASHEETS_DIR` before it writes into a subdirectory of it — which I can't verify since that module isn't in the public tree. Left the `os.makedirs(DATASHEETS_DIR, ...)` call in place (just later) rather than removing it outright, to avoid a blind guess against code I can't see or test.
- **`logs/`** — noticed the same leftover-empty-directory pattern from `test_step06_survey_logging.py` (it cleans up its own trace *file* via `os.remove`, but never the now-empty `logs/` directory `step_06_power.py` created). Not one of the three named instances, and low-impact (git doesn't track empty directories), so left untouched to keep this PR focused — flagging here in case it's worth a follow-up.

## Testing

New tests: `test_find_pdf_missing_dir.py` (3 tests covering missing-directory tolerance, a real match still working, and the short-value path never touching the filesystem), plus `test_resume_reconstruction.py`'s fixed test now runs unconditionally instead of skipping.

Full suite: `1169 passed, 31 skipped` (main baseline: `1160 passed, 32 skipped`) — 0 regressions, skip count down by exactly 1 (the fixed arrival-state-dependent skip). Verified the demo board's verdict is byte-identical before/after (`FAIL 2 / WARN 0 / UNRESOLVABLE 2`, matching the README). `make test` runs clean end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuUsvpeWybGW8jUGQhF1Bz
